### PR TITLE
Add color scheme, Format appBar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,7 +34,18 @@ class MyApp extends StatelessWidget {
         //
         // This works for code too, not just values: Most code changes can be
         // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme(
+          brightness: Brightness.dark,
+          primary: Color(0x00000000),
+          onPrimary: Color(0xff00fffb),
+          secondary: Color(0x00000000),
+          onSecondary: Color(0xffffffff),
+          tertiary: Color(0xffff4564),
+          error: Color(0xffcc0000),
+          onError: Color(0xffffffff),
+          surface: Color(0xff4a4a4a),
+          onSurface: Color(0xff00fffb),
+        ),
         useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
@@ -73,6 +84,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
     // This method is rerun every time setState is called, for instance as done
     // by the _incrementCounter method above.
     //
@@ -89,6 +101,7 @@ class _MyHomePageState extends State<MyHomePage> {
           // hamburger button to open side drawer
           leading: Builder(
             builder: (context) => IconButton(
+              color: colors.onSecondary,
               icon: Icon(Icons.menu),
               onPressed: () {
                 Scaffold.of(context).openDrawer();
@@ -98,7 +111,7 @@ class _MyHomePageState extends State<MyHomePage> {
           // TRY THIS: Try changing the color here to a specific color (to
           // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
           // change color while the other colors stay the same.
-          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+          backgroundColor: Theme.of(context).colorScheme.primary,
           // Here we take the value from the MyHomePage object that was created by
           // the App.build method, and use it to set our appbar title.
           title: Image.asset(
@@ -107,6 +120,8 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
           // page selection
           bottom: TabBar(
+            labelColor: colors.onPrimary,
+            unselectedLabelColor: colors.onSecondary,
             tabs: [
               Tab(
                 child: Text("Live")

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -99,7 +99,8 @@ class _MyHomePageState extends State<MyHomePage> {
         appBar: AppBar(
 
           // hamburger button to open side drawer
-          leading: Builder(
+          automaticallyImplyLeading: false,
+          /* leading: Builder(
             builder: (context) => IconButton(
               color: colors.onSecondary,
               icon: Icon(Icons.menu),
@@ -107,17 +108,52 @@ class _MyHomePageState extends State<MyHomePage> {
                 Scaffold.of(context).openDrawer();
               },
             ),
-          ),
+          ), */
           // TRY THIS: Try changing the color here to a specific color (to
           // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
           // change color while the other colors stay the same.
           backgroundColor: Theme.of(context).colorScheme.primary,
           // Here we take the value from the MyHomePage object that was created by
           // the App.build method, and use it to set our appbar title.
-          title: Image.asset(
-            'assets/WORDMARK PNG.png',
-            height: 120,
-          ),
+          title: /* Image.asset(
+                  'assets/WORDMARK PNG.png',
+                  height: 120,
+                ) */
+          
+          SizedBox(
+            width: double.infinity,
+            height:180,
+            child:Stack(
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Builder(
+                    builder: (context) => IconButton(
+                      color: colors.onSecondary,
+                      icon: Icon(Icons.menu),
+                      onPressed: () {
+                        Scaffold.of(context).openDrawer();
+                      },
+                    ),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.center,
+                  child: Image.asset(
+                    'assets/WORDMARK PNG.png',
+                    height: 120,
+                  )
+                ),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: Image.asset(
+                    'assets/hashtag-local-af.png',
+                    width: 80,
+                  )
+                )
+              ],
+            )),
+          centerTitle: true,
           // page selection
           bottom: TabBar(
             labelColor: colors.onPrimary,


### PR DESCRIPTION
I couldn't find the color scheme David mentioned in the assets folder, so I populated the app with a temporary color scheme for the time being. We can change that once we get the correct colors.

I also formatted the top bar to more closely match the pdf we were given. It's not an exact match yet though.