### PR TITLE
Add Progress Bar with Seek Support for On-Demand Playback

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -38,12 +38,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
 
 SPEC CHECKSUMS:
-  audio_service: aa99a6ba2ae7565996015322b0bb024e1d25c6fd
-  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
+  audio_service: cab6c1a0eaf01b5a35b567e11fa67d3cc1956910
+  audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
 
 PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -38,12 +38,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
 
 SPEC CHECKSUMS:
-  audio_service: cab6c1a0eaf01b5a35b567e11fa67d3cc1956910
-  audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
+  audio_service: aa99a6ba2ae7565996015322b0bb024e1d25c6fd
+  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 
 PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,5 +37,5 @@ void main() async {
     DeviceOrientation.portraitDown,
   ]);
   
-  runApp(MidtownRadioApp(settingsController: settingsController));
+  runApp(MidtownRadioApp(settingsController: settingsController,));
 }

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -44,56 +44,52 @@ class MidtownRadioState extends State<MidtownRadioStateful> {
       builder: (BuildContext context, Widget? child) {
         return MaterialApp(
           navigatorKey: navigatorKey,
-
           builder: (context, child) {
-            return Stack(
-              children: [
-                Scaffold(
-                  body: child,
+            return Overlay(
+              initialEntries: [
+                OverlayEntry(
+                  builder: (context) => Scaffold(
+                    body: child,
+                  ),
                 ),
-                StreamBuilder<PlaybackState>(
-                  stream: audioHandler.playbackState,
-                  builder: (context, snapshot) {
-                    if (!audioPlayerHandler.isPlaying) {
-                      return const SizedBox.shrink();
-                    }
-
-                    return Positioned(
-                      left: 0,
-                      right: 0,
-                      bottom: 0,
-                      child: PlayerWidget(
-                        navigatorKey: navigatorKey,
-                        audioPlayerHandler: audioPlayerHandler,
-                      ),
-                    );
-                  },
+                OverlayEntry(
+                  builder: (context) => StreamBuilder<MediaItem?>(
+                    stream: audioHandler.mediaItem,
+                    builder: (context, snapshot) {
+                      if (snapshot.data == null) {
+                        return const SizedBox.shrink();
+                      }
+                      return Positioned(
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        child: PlayerWidget(
+                          navigatorKey: navigatorKey,
+                          audioPlayerHandler: audioPlayerHandler,
+                        ),
+                      );
+                    },
+                  ),
                 ),
               ],
             );
           },
-
           initialRoute: HomePage.routeName,
-
           localizationsDelegates: const [
             AppLocalizations.delegate,
             GlobalMaterialLocalizations.delegate,
             GlobalWidgetsLocalizations.delegate,
             GlobalCupertinoLocalizations.delegate,
           ],
-
           supportedLocales: const [
             Locale('en', ''),
             Locale('fr', ''),
           ],
-
           onGenerateTitle: (BuildContext context) =>
               AppLocalizations.of(context)!.appTitle,
-
           theme: ThemeData(),
           darkTheme: ThemeData.dark(),
           themeMode: widget.settingsController.themeMode,
-
           onGenerateRoute: (RouteSettings routeSettings) {
             return MaterialPageRoute<void>(
               settings: routeSettings,

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -40,63 +40,83 @@ class MidtownRadioState extends State<MidtownRadioStateful> {
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
-        listenable: widget.settingsController,
-        builder: (BuildContext context, Widget? child) {
-          return MaterialApp(
-            navigatorKey: navigatorKey,
+      listenable: widget.settingsController,
+      builder: (BuildContext context, Widget? child) {
+        return MaterialApp(
+          navigatorKey: navigatorKey,
 
-            builder: (context, child) => Scaffold(
-                body: child,
-                bottomSheet: StreamBuilder<PlaybackState>(
-                    stream: audioHandler.playbackState,
-                    builder: (context, snapshot) {
-                      return (audioPlayerHandler.isPlaying)
-                          ? PlayerWidget(navigatorKey: navigatorKey)
-                          : const SizedBox.shrink();
-                    })),
-
-            initialRoute: HomePage.routeName,
-
-            localizationsDelegates: const [
-              AppLocalizations.delegate,
-              GlobalMaterialLocalizations.delegate,
-              GlobalWidgetsLocalizations.delegate,
-              GlobalCupertinoLocalizations.delegate,
-            ],
-
-            supportedLocales: const [
-              Locale('en', ''),
-              Locale('fr', ''),
-            ],
-
-            onGenerateTitle: (BuildContext context) =>
-                AppLocalizations.of(context)!.appTitle,
-
-            theme: ThemeData(),
-            darkTheme: ThemeData.dark(),
-            themeMode: widget.settingsController.themeMode,
-
-            onGenerateRoute: (RouteSettings routeSettings) {
-              return MaterialPageRoute<void>(
-                  settings: routeSettings,
-                  builder: (BuildContext context) {
-                    switch (routeSettings.name) {
-                      case HomePage.routeName:
-                        return const HomePage();
-                      case ListenLivePage.routeName:
-                        return const ListenLivePage();
-                      case OnDemandPage.routeName:
-                        return const OnDemandPage();
-                      case SettingsPage.routeName:
-                        return SettingsPage(
-                          controller: widget.settingsController,
-                        );
-                      default:
-                        return const ErrorPage();
+          builder: (context, child) {
+            return Stack(
+              children: [
+                Scaffold(
+                  body: child,
+                ),
+                StreamBuilder<PlaybackState>(
+                  stream: audioHandler.playbackState,
+                  builder: (context, snapshot) {
+                    if (!audioPlayerHandler.isPlaying) {
+                      return const SizedBox.shrink();
                     }
-                  });
-            },
-          );
-        });
+
+                    return Positioned(
+                      left: 0,
+                      right: 0,
+                      bottom: 0,
+                      child: PlayerWidget(
+                        navigatorKey: navigatorKey,
+                        audioPlayerHandler: audioPlayerHandler,
+                      ),
+                    );
+                  },
+                ),
+              ],
+            );
+          },
+
+          initialRoute: HomePage.routeName,
+
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+
+          supportedLocales: const [
+            Locale('en', ''),
+            Locale('fr', ''),
+          ],
+
+          onGenerateTitle: (BuildContext context) =>
+              AppLocalizations.of(context)!.appTitle,
+
+          theme: ThemeData(),
+          darkTheme: ThemeData.dark(),
+          themeMode: widget.settingsController.themeMode,
+
+          onGenerateRoute: (RouteSettings routeSettings) {
+            return MaterialPageRoute<void>(
+              settings: routeSettings,
+              builder: (BuildContext context) {
+                switch (routeSettings.name) {
+                  case HomePage.routeName:
+                    return const HomePage();
+                  case ListenLivePage.routeName:
+                    return const ListenLivePage();
+                  case OnDemandPage.routeName:
+                    return const OnDemandPage();
+                  case SettingsPage.routeName:
+                    return SettingsPage(
+                      controller: widget.settingsController,
+                    );
+                  default:
+                    return const ErrorPage();
+                }
+              },
+            );
+          },
+        );
+      },
+    );
   }
 }

--- a/lib/src/media_player/audio_player_handler.dart
+++ b/lib/src/media_player/audio_player_handler.dart
@@ -32,6 +32,7 @@ class AudioPlayerHandler extends BaseAudioHandler {
       //   _player.
       // })
       .then((_) {
+      _player.seek(Duration.zero);
       _isCurrentlyPlaying = item.title;
       playbackState.add(playbackState.value
           .copyWith(processingState: AudioProcessingState.ready, ));

--- a/lib/src/media_player/audio_player_handler.dart
+++ b/lib/src/media_player/audio_player_handler.dart
@@ -70,4 +70,9 @@ class AudioPlayerHandler extends BaseAudioHandler {
       processingState: AudioProcessingState.idle
     ));
   }
+    @override
+  Future<void> seek(Duration position) async {
+    await _player.seek(position);
+  }
+    Stream<Duration> get positionStream => _player.positionStream;
 }

--- a/lib/src/media_player/progress_bar.dart
+++ b/lib/src/media_player/progress_bar.dart
@@ -26,7 +26,6 @@ class ProgressBar extends StatelessWidget {
       stream: _positionDataStream,
       builder: (context, snapshot) {
         final data = snapshot.data;
-
         if (data == null || data.isLive) {
           return const Padding(
             padding: EdgeInsets.only(top: 4.0),
@@ -36,6 +35,7 @@ class ProgressBar extends StatelessWidget {
                 fontSize: 12.0,
                 color: Colors.red,
                 fontWeight: FontWeight.bold,
+                decoration: TextDecoration.none,
               ),
             ),
           );

--- a/lib/src/media_player/progress_bar.dart
+++ b/lib/src/media_player/progress_bar.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:audio_service/audio_service.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:ctwr_midtown_radio_app/main.dart';
+
+class ProgressBar extends StatelessWidget {
+  const ProgressBar({super.key});
+
+  Stream<_PositionData> get _positionDataStream =>
+      Rx.combineLatest3<MediaItem?, Duration, PlaybackState, _PositionData>(
+        audioHandler.mediaItem,
+        AudioService.position,
+        audioHandler.playbackState,
+        (mediaItem, position, playbackState) => _PositionData(
+          mediaItem: mediaItem,
+          position: position,
+          isLive: mediaItem?.extras?['isLive'] == true || mediaItem?.duration == null,
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return StreamBuilder<_PositionData>(
+      stream: _positionDataStream,
+      builder: (context, snapshot) {
+        final data = snapshot.data;
+
+        if (data == null || data.isLive) {
+          return const Padding(
+            padding: EdgeInsets.only(top: 4.0),
+            child: Text(
+              "🔴 On live",
+              style: TextStyle(
+                fontSize: 12.0,
+                color: Colors.red,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          );
+        }
+
+        final duration = data.mediaItem?.duration ?? Duration.zero;
+        final position = data.position;
+
+        return Padding(
+          padding: const EdgeInsets.only(top: 4.0),
+          child: LinearProgressIndicator(
+            minHeight: 8,
+            value: (position.inMilliseconds / duration.inMilliseconds).clamp(0.0, 1.0),
+            backgroundColor: Colors.grey[300],
+            color: theme.primaryColor,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _PositionData {
+  final MediaItem? mediaItem;
+  final Duration position;
+  final bool isLive;
+
+  _PositionData({
+    required this.mediaItem,
+    required this.position,
+    required this.isLive,
+  });
+}

--- a/lib/src/media_player/widget.dart
+++ b/lib/src/media_player/widget.dart
@@ -29,10 +29,10 @@ class PlayerWidget extends StatelessWidget {
           alignment: Alignment.bottomCenter,
           child: Container(
             padding: EdgeInsets.only(
-              top: 8.0,
+              top: 15.0,
               left: 8.0,
               right: 8.0,
-              bottom: safePadding + 30,
+              // bottom: 8.0, //safePadding, // + 30,
             ),
             decoration: BoxDecoration(
               color: theme.cardColor,

--- a/lib/src/media_player/widget.dart
+++ b/lib/src/media_player/widget.dart
@@ -1,13 +1,17 @@
-import 'package:ctwr_midtown_radio_app/main.dart';
+import 'package:ctwr_midtown_radio_app/src/media_player/progress_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:audio_service/audio_service.dart';
+import 'package:ctwr_midtown_radio_app/src/media_player/audio_player_handler.dart';
+import 'package:ctwr_midtown_radio_app/main.dart';
 
 class PlayerWidget extends StatelessWidget {
   final GlobalKey<NavigatorState> navigatorKey;
+  final AudioPlayerHandler audioPlayerHandler;
 
   const PlayerWidget({
     super.key,
-    required this.navigatorKey
+    required this.navigatorKey,
+    required this.audioPlayerHandler,
   });
 
   @override
@@ -18,69 +22,78 @@ class PlayerWidget extends StatelessWidget {
 
     return StreamBuilder<PlaybackState>(
       stream: audioHandler.playbackState,
-      builder:(context, snapshot) {
+      builder: (context, snapshot) {
         final isPlaying = audioPlayerHandler.isPlaying;
-        return Container(
-      
-      // can adjust this margin to raise this widget - I picked +20 arbitrairily
-      // safePadding puts it above any OS buttons like the IOS home swipe bar, so it should stay
-      padding: EdgeInsets.only(
-        top: 8.0,
-        left: 8.0,
-        right: 8.0,
-        bottom: safePadding + 30,
-      ),
-      decoration: BoxDecoration(
-        color: theme.cardColor,
-        //color: Colors.grey[200],
-        border: Border(top: BorderSide(color: theme.dividerColor)),
-      ),
-      child: Row(
-        children: [
-          // play/pause button
-          snapshot.data?.processingState == AudioProcessingState.buffering
-              ? const Padding(
-                  padding: EdgeInsets.all(8.0),
-                  child: SizedBox(
-                    width: 24,
-                    height: 24,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2.0,
-                    ),
-                  ),
-                )
-              : IconButton(
-                  icon: Icon(isPlaying
-                    ? Icons.pause
-                    : Icons.play_arrow),
-                  onPressed: () {
-                    if (isPlaying) {
-                      audioHandler.pause();
-                    } else if (audioPlayerHandler.isCurrentlyPlaying.isNotEmpty && audioPlayerHandler.isCurrentlyPlaying != "Nothing is loaded...") {
-                      audioHandler.play();
-                    }
-                  },
-                ),
-          Expanded(
-            child: Column(
+
+        return Align(
+          alignment: Alignment.bottomCenter,
+          child: Container(
+            padding: EdgeInsets.only(
+              top: 8.0,
+              left: 8.0,
+              right: 8.0,
+              bottom: safePadding + 30,
+            ),
+            decoration: BoxDecoration(
+              color: theme.cardColor,
+              border: Border(top: BorderSide(color: theme.dividerColor)),
+            ),
+            child: SafeArea(
+              top: false,
+              child: Column(
               mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  "Now Playing:",
-                  style: TextStyle(
-                    fontSize: 12,
-                  )
-                ),
-                Text(
-                  audioPlayerHandler.isCurrentlyPlaying,
-                  overflow: TextOverflow.ellipsis,
+                Row(
+                  children: [
+                    snapshot.data?.processingState == AudioProcessingState.buffering
+                        ? const Padding(
+                            padding: EdgeInsets.all(8.0),
+                            child: SizedBox(
+                              width: 24,
+                              height: 24,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2.0,
+                              ),
+                            ),
+                          )
+                        : IconButton(
+                            icon: Icon(
+                              isPlaying ? Icons.pause : Icons.play_arrow,
+                              color: theme.iconTheme.color,
+                            ),
+                            onPressed: () {
+                              if (isPlaying) {
+                                audioHandler.pause();
+                               } else if (audioPlayerHandler.isCurrentlyPlaying.isNotEmpty && audioPlayerHandler.isCurrentlyPlaying != "Nothing is loaded...") {
+                      audioHandler.play();
+                              }
+                            },
+                          ),
+                    Expanded(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                         Text("Now Playing:",
+                         style: Theme.of(context).textTheme.labelSmall,
+                         ),
+                          Text(
+                            audioPlayerHandler.isCurrentlyPlaying,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          ProgressBar(),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),
           ),
-        ],
-      ),
+          ),
+        );
+      },
     );
-  });
-}}
+  }
+}

--- a/lib/src/on_demand/view.dart
+++ b/lib/src/on_demand/view.dart
@@ -17,8 +17,7 @@ class _OnDemandPageState extends State<OnDemandPage> {
 
   List<String> filters = ['All'];
   late String selectedFilter;
-
-  // List<Episode> _displayedEpisodes = [];
+ // List<Episode> _displayedEpisodes = [];
   int itemsToLoad = 10;
   bool isLoadingMore = false;
   final ScrollController _scrollController = ScrollController();
@@ -39,9 +38,7 @@ class _OnDemandPageState extends State<OnDemandPage> {
 
   void _loadMoreEpisodes() {
     setState(() {
-      (() {
-        isLoadingMore = true;
-      });
+      isLoadingMore = true;
     });
 
     Future.delayed(const Duration(milliseconds: 100), () {
@@ -60,10 +57,7 @@ class _OnDemandPageState extends State<OnDemandPage> {
 
   @override
   Widget build(BuildContext context) {
-    return
-        // Column(
-        //   children: [
-        FutureBuilder(
+    return FutureBuilder(
       future: onDemandFuture,
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
@@ -86,7 +80,7 @@ class _OnDemandPageState extends State<OnDemandPage> {
 
           return Column(children: [
             DropdownButton<String>(
-              value: selectedFilter, // Set the current value
+              value: selectedFilter,// Set the current value
               items: filters.map<DropdownMenuItem<String>>((String value) {
                 return DropdownMenuItem<String>(
                   value: value,
@@ -123,6 +117,7 @@ class _OnDemandPageState extends State<OnDemandPage> {
                     podcastEpisodeName: show.episodeName,
                     podcastEpisodeDate: show.episodeDate,
                     podcastEpisodeStreamUrl: show.episodeStreamUrl,
+                    duration: show.duration, 
                   );
                 },
               ),
@@ -143,6 +138,7 @@ class _OnDemandListTile extends StatelessWidget {
     required this.podcastEpisodeName,
     required this.podcastEpisodeDate,
     required this.podcastEpisodeStreamUrl,
+    required this.duration,
   }) : super(key: key);
 
   final String podcastName;
@@ -150,24 +146,37 @@ class _OnDemandListTile extends StatelessWidget {
   final String podcastEpisodeName;
   final String podcastEpisodeDate;
   final String podcastEpisodeStreamUrl;
+  final String duration;
+
+  Duration _parseDuration(String duration) {
+    final parts = duration.split(':').map(int.parse).toList();
+    if (parts.length == 3) {
+      return Duration(hours: parts[0], minutes: parts[1], seconds: parts[2]);
+    } else if (parts.length == 2) {
+      return Duration(minutes: parts[0], seconds: parts[1]);
+    } else if (parts.length == 1) {
+      return Duration(seconds: parts[0]);
+    } else {
+      return Duration.zero;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<MediaItem?>(
-        stream: audioHandler.mediaItem, // Listen to the current media item
-        builder: (context, snapshot) {
-          final currentMediaItem = snapshot.data;
-          final isSelected = currentMediaItem?.id == podcastEpisodeStreamUrl;
+      stream: audioHandler.mediaItem,// Listen to the current media item
+      builder: (context, snapshot) {
+        final currentMediaItem = snapshot.data;
+        final isSelected = currentMediaItem?.id == podcastEpisodeStreamUrl;
 
-          return ListTile(
-              leading: Image.network(
-                  podcastImageUrl), // cachedImage != null ? Image.memory(cachedImage) : Image.network(podcastImageUrl),
+        return Column(
+          children: [
+            ListTile(
+              leading: Image.network(podcastImageUrl),// cachedImage != null ? Image.memory(cachedImage) : Image.network(podcastImageUrl),
               title: Text(
                 podcastEpisodeName,
                 maxLines: 1,
-                style: const TextStyle(
-                  fontWeight: FontWeight.bold,
-                ),
+                style: const TextStyle(fontWeight: FontWeight.bold),
               ),
               subtitle: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -180,14 +189,17 @@ class _OnDemandListTile extends StatelessWidget {
               selectedTileColor: Theme.of(context).highlightColor,
               onTap: () => audioPlayerHandler.setStream(
                 MediaItem(
-                  id: podcastEpisodeStreamUrl, 
+                  id: podcastEpisodeStreamUrl,
                   title: podcastEpisodeName,
                   album: podcastName,
                   artUri: Uri.parse(podcastImageUrl),
-                  )
-                )
-              );
-      }
+                  duration: _parseDuration(duration),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,8 +60,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-<<<<<<< Updated upstream
-=======
   # plugin:
   #   platforms:
   #     android:
@@ -70,7 +68,6 @@ flutter:
   #     ios:
   #       pluginClass: AudioServicePlugin
   #       # sharedDarwinSource: true
->>>>>>> Stashed changes
 
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in


### PR DESCRIPTION
✨ Features:
- Displays a visual progress bar for on-demand episodes
- Users can now drag the slider to seek forward or backward within the episode
- Shows a 🔴 “On live” label when streaming live content (instead of the progress bar)

💡 Notes:
- The Progress Bar is hidden when no media is loaded
- The slider works without crashing by ensuring a valid Overlay context

Tested on iPhone SE (3rd generation). Let me know if any UI tweaks are needed!